### PR TITLE
Remove donation top banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-# swisscows banner remover
+# Swisscows Banner Remover
+Do you like using https://swisscows.com but you are afraid, annoyed or distracted by the smiley guy  in the banner? Then fear no more my friend! This extension will help you to remove this unorthodox use of display render once and for all from your screen.
 
-Do you like using swisscows.com but you are afraid, annoyed, distracted by the smiley guy  in the banner? then fear no more my friend! This extension will help to remove this unorthodox use of display  render once and for all from your screen.
+## Installation
+It currently only works when activating development mode in your extensions menu and load the whole folder.
 
-## installation
-
-Currently only works when activating development mode in your extensions menu and load the whole folder.
-
-## todo
-
-[] adjust logo
-[] package it
-[] publish it
+## Todo
+- [ ] adjust logo
+- [ ] package it
+- [ ] publish it

--- a/ad-remover.css
+++ b/ad-remover.css
@@ -1,4 +1,3 @@
-.sales,
-.banners-wrap {
-	display: none;
+.top-banner, .sales, .banners-wrap {
+	display: none !important;
 }

--- a/popup.html
+++ b/popup.html
@@ -1,18 +1,19 @@
 <!doctype html>
 <html>
-	    <head>
-		            <title>Swisscows Banner Remover</title>
-			        </head>
-				    <style type="text/css">
-	body {
-		            margin: 5px;
-			            }
-		h1 {
-				    font-size: 15px;
-				    	    text-align: center;
-					            }
-		    </style>
-		        <body>
-				        <h1>My duty to humankind is done!</h1>
-					    </body>
+	<head>
+		<title>Swisscows Banner Remover</title>
+		<style>
+			body {
+				margin: 5px;
+			}
+		
+			h1 {
+				font-size: 15px;
+				text-align: center;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>My duty to humankind is done!</h1>
+	</body>
 </html>


### PR DESCRIPTION
This PR removes the donation top banner as well. I also added `!important` to enforce it. Otherwise it could happen that the website is using it and the extension wouldn't work.
![image](https://user-images.githubusercontent.com/20150243/107981184-e964ca00-6fc1-11eb-8f55-f2f002b77520.png)

![image](https://user-images.githubusercontent.com/20150243/107981468-67c16c00-6fc2-11eb-8a18-8bd25ec38660.png)
