### PR TITLE
feat: more compact search page

### DIFF
--- a/ad-remover.css
+++ b/ad-remover.css
@@ -7,9 +7,17 @@
 }
 
 .main {
-	padding-top: 9em !important;
+	padding-top: 8em !important;
 }
 
 .page-results {
-	padding-bottom: 1em !important
+	padding: 0.5em 0 !important
+}
+
+.page-results .item {
+	margin-bottom: 1.6em !important;
+}
+
+.web-pagination {
+	margin-top: 2em !important;
 }

--- a/ad-remover.css
+++ b/ad-remover.css
@@ -1,4 +1,4 @@
-.top-banner, .sales, .banners-wrap {
+.top-banner, .sales, .banners-wrap, .web-results-sale {
 	display: none !important;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Swisscows Banner Remover",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"manifest_version": 3,
 	"description": "Do you like using swisscows.com but you are afraid, annoyed, distracted by the smiley guy in the banner? then fear no more my friend! This extension will help to remove this unorthodox use of display render once and for all from your screen.",
 	"action": {


### PR DESCRIPTION
closes #5

## Before
![before](https://user-images.githubusercontent.com/20150243/112456775-5c98f300-8d5b-11eb-8f45-5aac2594e429.png)

## After
![after](https://user-images.githubusercontent.com/20150243/112456780-5e62b680-8d5b-11eb-9c86-b917e0d445fa.png)